### PR TITLE
Fix handling of typesVersions

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -1398,7 +1398,7 @@ namespace ts {
         let packageName: string;
         if (rest === undefined) ({ packageName, rest } = parsePackageName(moduleName!));
         if (rest !== "") { // If "rest" is empty, we just did this search above.
-            if(packageDirectory === undefined) packageDirectory = combinePaths(nodeModulesDirectory!, packageName!);
+            if (packageDirectory === undefined) packageDirectory = combinePaths(nodeModulesDirectory!, packageName!);
 
             // Don't use a "types" or "main" from here because we're not loading the root, but a subdirectory -- just here for the packageId and path mappings.
             packageInfo = getPackageJsonInfo(packageDirectory, !nodeModulesDirectoryExists, state);


### PR DESCRIPTION
Fixes import of `@jest/types/build/Config`.

`@jest/types` uses a `typesVersions` configuration to map `./build/Config` to `./build/ts3.4/Config`

However, specifically when importing a sub-path of a package, it seems that yarn 2's TSC patch was not respecting typesVersions.
