### PR TITLE
fix: autocomplete on subPath imports

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -276,7 +276,7 @@ namespace ts {
     }
     const nodeModulesAtTypes = combinePaths("node_modules", "@types");
 
-    function getPnpTypeRoots(currentDirectory: string) {
+    export function getPnpTypeRoots(currentDirectory: string) {
         if (!isPnpAvailable()) {
             return [];
         }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "extends": "../tsconfig-base",
     "compilerOptions": {
-        "outFile": "../../built/local/services.js"
+        "outFile": "../../built/local/services.js",
+        "types": [
+            "node"
+        ]
     },
     "references": [
         { "path": "../shims" },


### PR DESCRIPTION
Fixes autocomplete for subpaths of packages and workspaces


```ts
import '@yarnpkg/core/<empty autocomplete>'
// app is a `link:./src` dependency
import 'app/<empty autocomplete>'
```