### PR TITLE
fix: enable pnp for `typingsInstaller` and `watchGuard`

### DIFF
--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -210,6 +210,9 @@ namespace ts.server {
                     }
                     try {
                         const args = [combinePaths(__dirname, "watchGuard.js"), path];
+                        if (typeof process.versions.pnp !== "undefined") {
+                            args.unshift('-r', require.resolve('pnpapi'));
+                        }
                         if (logger.hasLevel(LogLevel.verbose)) {
                             logger.info(`Starting ${process.execPath} with args:${stringifyIndented(args)}`);
                         }
@@ -595,6 +598,10 @@ namespace ts.server {
                         execArgv.push(`--${match[1]}=${currentPort + 1}`);
                         break;
                     }
+                }
+
+                if (typeof process.versions.pnp !== "undefined") {
+                    execArgv.unshift('-r', require.resolve('pnpapi'));
                 }
 
                 this.installer = childProcess.fork(combinePaths(__dirname, "typingsInstaller.js"), args, { execArgv });


### PR DESCRIPTION
Ref https://github.com/yarnpkg/berry/issues/2662